### PR TITLE
added ssl check in config to configure ssl in drivers

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ You have to provide a configuration with the following information:
     module.path=            # You can specify the location of your custom plugin.
     db.hostname=localhost   # Address of your persistence.
     db.port=9985            # Port of yout persistence database.
+    ssl=true                # In order to use HTTPS, set ssl to true else set it to false.
 
     # If you choose bigchaindb you have to provide this:
     secret=                 # A secret that serves as a seed.
@@ -68,6 +69,11 @@ You have to provide a configuration with the following information:
     db.password=test        # If you are using authentication, mongodb password.
     db.name=test            # Mongodb database name
     db.collection=col       # Mongodb collection name
+
+    # If you choose elastic-search you have to provide this:
+    db.username=elastic     # If you are using authentication, elasticsearch username.
+    db.password=changeme    # If you are using authentication, elasticsearch password.
+    db.index=oceandb        # Elasticsearch index name
 ```
 
 ## Environment variables

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ You have to provide a configuration with the following information:
     module.path=            # You can specify the location of your custom plugin.
     db.hostname=localhost   # Address of your persistence.
     db.port=9985            # Port of yout persistence database.
-    ssl=true                # In order to use HTTPS, set ssl to true else set it to false.
+    db.ssl=true             # In order to use HTTPS, set ssl to true else set it to false.
 
     # If you choose bigchaindb you have to provide this:
     secret=                 # A secret that serves as a seed.

--- a/tests/oceandb.ini
+++ b/tests/oceandb.ini
@@ -10,5 +10,5 @@ db.port=9984
 db.namespace=namespace
 db.app_id=
 db.app_key=
-ssl=false
+db.ssl=false
 

--- a/tests/oceandb.ini
+++ b/tests/oceandb.ini
@@ -10,4 +10,5 @@ db.port=9984
 db.namespace=namespace
 db.app_id=
 db.app_key=
+ssl=false
 


### PR DESCRIPTION
## Description

This interface is lacking a check for SSL, which tells the implementing drivers whether they should use SSL in their connections to persistence db or not. So, I have added a keypair in config file, which implementing driver should take into account while configuring connections. 

If ssl=true, drivers should use HTTPS connections
If ssl=false, drivers should use HTTP connections

*Note* that user is responsible to enable/disable SSL in their persistence db and then appropriately configure `ssl` option in config file.

## Is this PR related with an open issue?
No. It is an minor but important enhancement

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
 
## Checklist:

- [x] Follows the code style of this project.
- [x] Tests Cover Changes
- [x] Documentation

#### Funny gif

![](https://media.giphy.com/media/xT77XWum9yH7zNkFW0/giphy.gif)